### PR TITLE
Add blq/alq plots for censored vpc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     ggplot2,
     stats,
     fastDummies,
-    utils
+    utils,
+    egg
 Suggests:
     cluster,
     dplyr,

--- a/R/plot.R
+++ b/R/plot.R
@@ -28,7 +28,7 @@
 #'  \code{\link{censoring}} was performed. 
 #' @param censoring.output A character string specifying whether to return percentage of blq/alq plots as an
 #' arranged \code{"grid"} or as elements in a \code{"list"}. Only applicable if \code{censoring.type != "none"}.
-#' @param ... Additional arguments for \code{\link{egg::ggarrange}} e.g., \code{ncol} and \code{nrow}.
+#' @param ... Additional arguments for \code{\link[egg]{ggarrange}} e.g., \code{ncol} and \code{nrow}.
 #' Only used if \code{censoring.type != "none"} and \code{censoring.output == "grid"}.
 #' @return A \code{ggplot} object.
 #' @seealso

--- a/man/plot.tidyvpcobj.Rd
+++ b/man/plot.tidyvpcobj.Rd
@@ -23,13 +23,15 @@
   legend.position = "top",
   facet.scales = "free",
   custom.theme = "ggplot2::theme_bw",
+  censoring.type = c("none", "both", "blq", "alq"),
+  censoring.output = c("grid", "list"),
   ...
 )
 }
 \arguments{
 \item{x}{A \code{tidyvpcobj}.}
 
-\item{facet}{Set to \code{TRUE} to facet plot by quantile (continuous VPC) or 
+\item{facet}{Set to \code{TRUE} to facet plot by quantile (continuous VPC) or
 category (categorical VPC).}
 
 \item{show.points}{Should the observed data points be plotted?}
@@ -59,15 +61,22 @@ category (categorical VPC).}
 
 \item{ribbon.alpha}{Numeric value specifying transparency of ribbon.}
 
-\item{legend.position}{A character string specifying the position of the legend. Options are 
+\item{legend.position}{A character string specifying the position of the legend. Options are
 \code{"top", "bottom", "left", "right"}.}
 
-\item{facet.scales}{A character string specifying the \code{scales} argument to use for faceting. Options 
+\item{facet.scales}{A character string specifying the \code{scales} argument to use for faceting. Options
 are \code{"free", "fixed"}.}
 
 \item{custom.theme}{A character string specifying theme from ggplot2 package.}
 
-\item{...}{Further arguments can be specified but are ignored.}
+\item{censoring.type}{A character string specifying additional blq/alq plots to include. Only applicable if
+\code{\link{censoring}} was performed.}
+
+\item{censoring.output}{A character string specifying whether to return percentage of blq/alq plots as an
+arranged \code{"grid"} or as elements in a \code{"list"}. Only applicable if \code{censoring.type != "none"}.}
+
+\item{...}{Additional arguments for \code{\link{egg::ggarrange}} e.g., \code{ncol} and \code{nrow}.
+Only used if \code{censoring.type != "none"} and \code{censoring.output == "grid"}.}
 }
 \value{
 A \code{ggplot} object.

--- a/man/plot.tidyvpcobj.Rd
+++ b/man/plot.tidyvpcobj.Rd
@@ -75,7 +75,7 @@ are \code{"free", "fixed"}.}
 \item{censoring.output}{A character string specifying whether to return percentage of blq/alq plots as an
 arranged \code{"grid"} or as elements in a \code{"list"}. Only applicable if \code{censoring.type != "none"}.}
 
-\item{...}{Additional arguments for \code{\link{egg::ggarrange}} e.g., \code{ncol} and \code{nrow}.
+\item{...}{Additional arguments for \code{\link[egg]{ggarrange}} e.g., \code{ncol} and \code{nrow}.
 Only used if \code{censoring.type != "none"} and \code{censoring.output == "grid"}.}
 }
 \value{


### PR DESCRIPTION
This PR closes #21 by adding support for generating percentage blq/alq plots using `plot.tidyvpcobj`. For VPC with censoring, users can supply arguments `censoring.type` (options are `'none'`, `'blq'`, `'alq'`, or `'both'`, defaults to `'none'`) and `censoring.output` (options are `'grid'` or `'list'`, defaults to `'grid'`).

If `censoring.output = 'grid'`, the plots will be arranged into single grid plot. Users may pass additional arguments via ellipsis to `egg::ggarrange` e.g., `nrow = 1`, `ncol = 2` in order to customize plots in grid arrangement.

If `censoring.output = 'list'`, the resulting plots will be returned individually as elements in list.


Example usage is below:

```
library(tidyvpc)
obs_data <- obs_data[MDV == 0]
sim_data <- sim_data[MDV == 0]
obs_data$LLOQ <- obs_data[, ifelse(STUDY == "Study A", 50, 25)]
obs_data$ULOQ <- obs_data[, ifelse(STUDY == "Study A", 125, 100)]

vpc <- observed(obs_data, x = TIME, y = DV) |>
  simulated(sim_data, y = DV) |>
  censoring(blq = DV < LLOQ, lloq = LLOQ,  alq = DV > ULOQ, uloq = ULOQ) |>
  stratify(~ STUDY) |>
  binning(bin = NTIME) |>
  vpcstats(qpred = c(0.1, 0.5, 0.9))

# If blq data, users can supply censoring.type = "blq"
plot(vpc, censoring.type = "blq", censoring.output = "grid")

# If alq data, users can supply censoring.type = "alq"
plot(vpc, censoring.type = "alq", censoring.output = "grid", ncol = 2, nrow = 1)

# If both blq and alq data, users can supply censoring.type = "both"
vpc_plots <- plot(vpc, censoring.type = "both", censoring.output = "list")
```

By default, when `censoring.tidyvpcobj` is used, no percentage blq/alq plots will be returned e.g., default for `censoring.type = 'none'`. If users specify `censoring.type='both'` and only blq censoring was performed, for example, they will receive an error stating e.g., `pctalq data.frame was not found in tidyvpcobj. Use censoring() to create censored data for plotting alq`.

