### PR TITLE
Ensure vpc and censored xaxis align in plot.tidyvpcobj

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -529,12 +529,23 @@ plot_censored <-
     if (method == "binning" &&
         any(show.binning, show.boundaries, show.points)) {
       if (any(show.binning, show.boundaries)) {
-        xlim_df <-
-          bininfo(vpc)[, .(x = sort(unique(c(xleft, xright)))), by = names(vpc$strat)]
+        if (!is.null(vpc$strat)) {
+          xlim_df <-
+            bininfo(vpc)[, .(x = sort(unique(c(xleft, xright)))), by = names(vpc$strat)]
+        } else {
+          xlim_df <-
+            bininfo(vpc)[, .(x = sort(unique(c(xleft, xright))))]
+        }
       } else {
-        xlim_df <-
-          copy(vpc$obs)[!(blq |
-                            alq)][, .(x = max(x)), by = names(vpc$strat)]
+        if (!is.null(vpc$strat)) {
+          xlim_df <-
+            copy(vpc$obs)[!(blq |
+                              alq)][, .(x = max(x)), by = names(vpc$strat)]
+        } else {
+          xlim_df <-
+            copy(vpc$obs)[!(blq |
+                              alq)][, .(x = max(x))]
+        }
       }
       g <- g + ggplot2::geom_rug(
         data = xlim_df,

--- a/R/plot.R
+++ b/R/plot.R
@@ -136,12 +136,30 @@ plot.tidyvpcobj <- function(x,
     
     if (censoring.type %in% c("both", "blq")) {
       g_blq <-
-        plot_censored(vpc, type = "blq", facet.scales, custom.theme, legend.position)
+        plot_censored(
+          vpc,
+          type = "blq",
+          facet.scales,
+          custom.theme,
+          legend.position,
+          show.points,
+          show.boundaries,
+          show.binning
+        )
     }
     
     if (censoring.type %in% c("both", "alq")) {
       g_alq <-
-        plot_censored(vpc, type = "alq", facet.scales, custom.theme, legend.position)
+        plot_censored(
+          vpc,
+          type = "alq",
+          facet.scales,
+          custom.theme,
+          legend.position,
+          show.points,
+          show.boundaries,
+          show.binning
+        )
     }
     
     grid_list <-
@@ -450,12 +468,16 @@ plot_censored <-
            facet.scales = c("free", "fixed"),
            custom.theme,
            legend.position,
-           ...) {
+           show.points,
+           show.boundaries,
+           show.binning) {
     
     stopifnot(inherits(vpc, "tidyvpcobj"))
     hi <- lo <- md <- xbin <- y <- NULL
+    . <- list
     
     method <- vpc$vpc.method$method
+
     if(method == "binning") {
       xvar <- "xbin"
     } else {
@@ -502,6 +524,25 @@ plot_censored <-
                    observed = "black")
       ) +
       labs(x = "TIME", y = paste0("% ", toupper(type)))
+    
+    # ensure x axis is same scale given options in vpc plot that can affect xmax
+    if (method == "binning" &&
+        any(show.binning, show.boundaries, show.points)) {
+      if (any(show.binning, show.boundaries)) {
+        xlim_df <-
+          bininfo(vpc)[, .(x = sort(unique(c(xleft, xright)))), by = names(vpc$strat)]
+      } else {
+        xlim_df <-
+          copy(vpc$obs)[!(blq |
+                            alq)][, .(x = max(x)), by = names(vpc$strat)]
+      }
+      g <- g + ggplot2::geom_rug(
+        data = xlim_df,
+        ggplot2::aes(x = x),
+        sides = "t",
+        alpha = 0
+      )
+    }
     
     # add theme
     if (is.null(custom.theme)) {

--- a/tests/testthat/_snaps/plot/censored-plot-with-aql.svg
+++ b/tests/testthat/_snaps/plot/censored-plot-with-aql.svg
@@ -765,26 +765,34 @@
 <polyline points='37.69,508.87 366.00,508.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,453.95 366.00,453.95 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,399.03 366.00,399.03 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,536.33 366.00,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,481.41 366.00,481.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,426.49 366.00,426.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,371.58 366.00,371.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,536.33 58.97,492.39 69.91,426.49 84.32,392.99 91.93,382.56 107.53,360.59 118.63,371.03 144.26,382.56 191.30,470.43 247.32,514.36 351.08,536.33 351.08,536.33 247.32,536.33 191.30,536.33 144.26,525.89 118.63,492.39 107.53,514.36 91.93,514.36 84.32,514.36 69.91,536.33 58.97,536.33 52.61,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,536.33 58.97,492.39 69.91,426.49 84.32,392.99 91.93,382.56 107.53,360.59 118.63,371.03 144.26,382.56 191.30,470.43 247.32,514.36 351.08,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,536.33 247.32,536.33 191.30,536.33 144.26,525.89 118.63,492.39 107.53,514.36 91.93,514.36 84.32,514.36 69.91,536.33 58.97,536.33 52.61,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,536.33 58.97,536.33 69.91,492.39 84.32,470.43 91.93,448.46 107.53,448.46 118.63,448.46 144.26,470.43 191.30,514.36 247.32,536.33 351.08,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,536.33 58.97,492.39 69.91,448.46 84.32,470.43 91.93,448.46 107.53,426.49 118.63,448.46 144.26,448.46 191.30,514.36 247.32,514.36 351.08,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,536.33 59.14,492.39 67.66,426.49 78.88,392.99 84.81,382.56 96.95,360.59 105.59,371.03 125.55,382.56 162.17,470.43 205.78,514.36 286.57,536.33 286.57,536.33 205.78,536.33 162.17,536.33 125.55,525.89 105.59,492.39 96.95,514.36 84.81,514.36 78.88,514.36 67.66,536.33 59.14,536.33 54.19,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,536.33 59.14,492.39 67.66,426.49 78.88,392.99 84.81,382.56 96.95,360.59 105.59,371.03 125.55,382.56 162.17,470.43 205.78,514.36 286.57,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,536.33 205.78,536.33 162.17,536.33 125.55,525.89 105.59,492.39 96.95,514.36 84.81,514.36 78.88,514.36 67.66,536.33 59.14,536.33 54.19,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,536.33 59.14,536.33 67.66,492.39 78.88,470.43 84.81,448.46 96.95,448.46 105.59,448.46 125.55,470.43 162.17,514.36 205.78,536.33 286.57,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,536.33 59.14,492.39 67.66,448.46 78.88,470.43 84.81,448.46 96.95,426.49 105.59,448.46 125.55,448.46 162.17,514.36 205.78,514.36 286.57,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='351.81' x2='52.61' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='351.81' x2='56.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='351.81' x2='62.85' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='351.81' x2='73.63' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='351.81' x2='81.48' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='351.81' x2='90.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='351.81' x2='107.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='351.81' x2='108.15' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='351.81' x2='145.23' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='351.81' x2='181.92' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='351.81' x2='247.55' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='351.81' x2='351.08' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -799,24 +807,32 @@
 <polyline points='386.20,504.94 714.52,504.94 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,442.18 714.52,442.18 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,379.42 714.52,379.42 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,536.33 714.52,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,473.56 714.52,473.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,410.80 714.52,410.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,523.77 407.54,492.08 420.30,416.76 433.40,360.59 446.28,385.70 460.03,385.70 472.27,398.25 495.87,398.25 549.84,454.42 600.94,498.67 699.60,529.74 699.60,536.33 600.94,536.33 549.84,523.77 495.87,486.12 472.27,473.56 460.03,473.56 446.28,473.56 433.40,486.12 420.30,511.22 407.54,536.33 401.13,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,523.77 407.54,492.08 420.30,416.76 433.40,360.59 446.28,385.70 460.03,385.70 472.27,398.25 495.87,398.25 549.84,454.42 600.94,498.67 699.60,529.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,536.33 600.94,536.33 549.84,523.77 495.87,486.12 472.27,473.56 460.03,473.56 446.28,473.56 433.40,486.12 420.30,511.22 407.54,536.33 401.13,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,536.33 407.54,523.77 420.30,473.56 433.40,435.91 446.28,435.91 460.03,423.35 472.27,435.91 495.87,448.46 549.84,486.12 600.94,523.77 699.60,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,536.33 407.54,511.22 420.30,473.56 433.40,448.46 446.28,435.91 460.03,435.91 472.27,448.46 495.87,486.12 549.84,498.67 600.94,523.77 699.60,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,523.77 407.54,492.08 419.01,416.76 430.79,360.59 442.38,385.70 454.74,385.70 465.75,398.25 486.97,398.25 535.51,454.42 581.46,498.67 670.19,529.74 670.19,536.33 581.46,536.33 535.51,523.77 486.97,486.12 465.75,473.56 454.74,473.56 442.38,473.56 430.79,486.12 419.01,511.22 407.54,536.33 401.77,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,523.77 407.54,492.08 419.01,416.76 430.79,360.59 442.38,385.70 454.74,385.70 465.75,398.25 486.97,398.25 535.51,454.42 581.46,498.67 670.19,529.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,536.33 581.46,536.33 535.51,523.77 486.97,486.12 465.75,473.56 454.74,473.56 442.38,473.56 430.79,486.12 419.01,511.22 407.54,536.33 401.77,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,536.33 407.54,523.77 419.01,473.56 430.79,435.91 442.38,435.91 454.74,423.35 465.75,435.91 486.97,448.46 535.51,486.12 581.46,523.77 670.19,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,536.33 407.54,511.22 419.01,473.56 430.79,448.46 442.38,435.91 454.74,435.91 465.75,448.46 486.97,486.12 535.51,498.67 581.46,523.77 670.19,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='351.81' x2='401.13' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='351.81' x2='404.21' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='351.81' x2='413.19' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='351.81' x2='424.42' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='351.81' x2='437.45' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='351.81' x2='447.43' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='351.81' x2='458.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='351.81' x2='473.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='351.81' x2='510.64' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='351.81' x2='556.67' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='351.81' x2='624.27' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='351.81' x2='699.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -894,32 +910,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
@@ -1672,26 +1680,34 @@
 <polyline points='37.69,508.87 366.00,508.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,453.95 366.00,453.95 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,399.03 366.00,399.03 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,536.33 366.00,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,481.41 366.00,481.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,426.49 366.00,426.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,371.58 366.00,371.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,536.33 58.97,492.39 69.91,426.49 84.32,392.99 91.93,382.56 107.53,360.59 118.63,371.03 144.26,382.56 191.30,470.43 247.32,514.36 351.08,536.33 351.08,536.33 247.32,536.33 191.30,536.33 144.26,525.89 118.63,492.39 107.53,514.36 91.93,514.36 84.32,514.36 69.91,536.33 58.97,536.33 52.61,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,536.33 58.97,492.39 69.91,426.49 84.32,392.99 91.93,382.56 107.53,360.59 118.63,371.03 144.26,382.56 191.30,470.43 247.32,514.36 351.08,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,536.33 247.32,536.33 191.30,536.33 144.26,525.89 118.63,492.39 107.53,514.36 91.93,514.36 84.32,514.36 69.91,536.33 58.97,536.33 52.61,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,536.33 58.97,536.33 69.91,492.39 84.32,470.43 91.93,448.46 107.53,448.46 118.63,448.46 144.26,470.43 191.30,514.36 247.32,536.33 351.08,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,536.33 58.97,492.39 69.91,448.46 84.32,470.43 91.93,448.46 107.53,426.49 118.63,448.46 144.26,448.46 191.30,514.36 247.32,514.36 351.08,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,536.33 59.14,492.39 67.66,426.49 78.88,392.99 84.81,382.56 96.95,360.59 105.59,371.03 125.55,382.56 162.17,470.43 205.78,514.36 286.57,536.33 286.57,536.33 205.78,536.33 162.17,536.33 125.55,525.89 105.59,492.39 96.95,514.36 84.81,514.36 78.88,514.36 67.66,536.33 59.14,536.33 54.19,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,536.33 59.14,492.39 67.66,426.49 78.88,392.99 84.81,382.56 96.95,360.59 105.59,371.03 125.55,382.56 162.17,470.43 205.78,514.36 286.57,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,536.33 205.78,536.33 162.17,536.33 125.55,525.89 105.59,492.39 96.95,514.36 84.81,514.36 78.88,514.36 67.66,536.33 59.14,536.33 54.19,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,536.33 59.14,536.33 67.66,492.39 78.88,470.43 84.81,448.46 96.95,448.46 105.59,448.46 125.55,470.43 162.17,514.36 205.78,536.33 286.57,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,536.33 59.14,492.39 67.66,448.46 78.88,470.43 84.81,448.46 96.95,426.49 105.59,448.46 125.55,448.46 162.17,514.36 205.78,514.36 286.57,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='351.81' x2='52.61' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='351.81' x2='56.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='351.81' x2='62.85' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='351.81' x2='73.63' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='351.81' x2='81.48' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='351.81' x2='90.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='351.81' x2='107.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='351.81' x2='108.15' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='351.81' x2='145.23' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='351.81' x2='181.92' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='351.81' x2='247.55' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='351.81' x2='351.08' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -1701,24 +1717,32 @@
 <polyline points='386.20,504.94 714.52,504.94 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,442.18 714.52,442.18 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,379.42 714.52,379.42 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,536.33 714.52,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,473.56 714.52,473.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,410.80 714.52,410.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,523.77 407.54,492.08 420.30,416.76 433.40,360.59 446.28,385.70 460.03,385.70 472.27,398.25 495.87,398.25 549.84,454.42 600.94,498.67 699.60,529.74 699.60,536.33 600.94,536.33 549.84,523.77 495.87,486.12 472.27,473.56 460.03,473.56 446.28,473.56 433.40,486.12 420.30,511.22 407.54,536.33 401.13,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,523.77 407.54,492.08 420.30,416.76 433.40,360.59 446.28,385.70 460.03,385.70 472.27,398.25 495.87,398.25 549.84,454.42 600.94,498.67 699.60,529.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,536.33 600.94,536.33 549.84,523.77 495.87,486.12 472.27,473.56 460.03,473.56 446.28,473.56 433.40,486.12 420.30,511.22 407.54,536.33 401.13,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,536.33 407.54,523.77 420.30,473.56 433.40,435.91 446.28,435.91 460.03,423.35 472.27,435.91 495.87,448.46 549.84,486.12 600.94,523.77 699.60,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,536.33 407.54,511.22 420.30,473.56 433.40,448.46 446.28,435.91 460.03,435.91 472.27,448.46 495.87,486.12 549.84,498.67 600.94,523.77 699.60,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,523.77 407.54,492.08 419.01,416.76 430.79,360.59 442.38,385.70 454.74,385.70 465.75,398.25 486.97,398.25 535.51,454.42 581.46,498.67 670.19,529.74 670.19,536.33 581.46,536.33 535.51,523.77 486.97,486.12 465.75,473.56 454.74,473.56 442.38,473.56 430.79,486.12 419.01,511.22 407.54,536.33 401.77,536.33 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,523.77 407.54,492.08 419.01,416.76 430.79,360.59 442.38,385.70 454.74,385.70 465.75,398.25 486.97,398.25 535.51,454.42 581.46,498.67 670.19,529.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,536.33 581.46,536.33 535.51,523.77 486.97,486.12 465.75,473.56 454.74,473.56 442.38,473.56 430.79,486.12 419.01,511.22 407.54,536.33 401.77,536.33 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,536.33 407.54,523.77 419.01,473.56 430.79,435.91 442.38,435.91 454.74,423.35 465.75,435.91 486.97,448.46 535.51,486.12 581.46,523.77 670.19,536.33 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,536.33 407.54,511.22 419.01,473.56 430.79,448.46 442.38,435.91 454.74,435.91 465.75,448.46 486.97,486.12 535.51,498.67 581.46,523.77 670.19,536.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='351.81' x2='401.13' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='351.81' x2='404.21' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='351.81' x2='413.19' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='351.81' x2='424.42' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='351.81' x2='437.45' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='351.81' x2='447.43' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='351.81' x2='458.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='351.81' x2='473.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='351.81' x2='510.64' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='351.81' x2='556.67' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='351.81' x2='624.27' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='351.81' x2='699.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -1781,32 +1805,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/plot/censored-plot-with-bql-aql.svg
+++ b/tests/testthat/_snaps/plot/censored-plot-with-bql-aql.svg
@@ -896,27 +896,35 @@
 <polyline points='37.69,315.52 366.00,315.52 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,293.40 366.00,293.40 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,271.29 366.00,271.29 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,353.11 77.27,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,353.11 138.36,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,353.11 199.44,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,353.11 260.52,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,353.11 321.60,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,353.11 97.17,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,353.11 192.28,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,353.11 287.39,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,348.69 366.00,348.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,326.57 366.00,326.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,304.46 366.00,304.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,282.34 366.00,282.34 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,260.23 366.00,260.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,353.11 46.73,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,353.11 107.81,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,353.11 168.90,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,353.11 229.98,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,353.11 291.06,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,353.11 352.14,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,260.23 58.97,295.61 69.91,327.46 84.32,334.54 91.93,334.54 107.53,323.92 118.63,313.31 144.26,302.69 191.30,299.15 247.32,292.07 351.08,270.84 351.08,292.07 247.32,302.69 191.30,306.23 144.26,318.70 118.63,338.07 107.53,345.15 91.93,348.69 84.32,348.69 69.91,348.69 58.97,323.92 52.61,279.78 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,260.23 58.97,295.61 69.91,327.46 84.32,334.54 91.93,334.54 107.53,323.92 118.63,313.31 144.26,302.69 191.30,299.15 247.32,292.07 351.08,270.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,292.07 247.32,302.69 191.30,306.23 144.26,318.70 118.63,338.07 107.53,345.15 91.93,348.69 84.32,348.69 69.91,348.69 58.97,323.92 52.61,279.78 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,267.31 58.97,306.23 69.91,339.84 84.32,345.15 91.93,343.38 107.53,338.07 118.63,327.46 144.26,309.77 191.30,302.69 247.32,299.15 351.08,281.46 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,270.84 58.97,313.31 69.91,345.15 84.32,348.69 91.93,341.61 107.53,338.07 118.63,323.92 144.26,306.23 191.30,302.69 247.32,302.69 351.08,274.38 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,353.11 49.61,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,353.11 144.73,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,353.11 239.84,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,353.11 334.95,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,260.23 59.14,295.61 67.66,327.46 78.88,334.54 84.81,334.54 96.95,323.92 105.59,313.31 125.55,302.69 162.17,299.15 205.78,292.07 286.57,270.84 286.57,292.07 205.78,302.69 162.17,306.23 125.55,318.70 105.59,338.07 96.95,345.15 84.81,348.69 78.88,348.69 67.66,348.69 59.14,323.92 54.19,279.78 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,260.23 59.14,295.61 67.66,327.46 78.88,334.54 84.81,334.54 96.95,323.92 105.59,313.31 125.55,302.69 162.17,299.15 205.78,292.07 286.57,270.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,292.07 205.78,302.69 162.17,306.23 125.55,318.70 105.59,338.07 96.95,345.15 84.81,348.69 78.88,348.69 67.66,348.69 59.14,323.92 54.19,279.78 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,267.31 59.14,306.23 67.66,339.84 78.88,345.15 84.81,343.38 96.95,338.07 105.59,327.46 125.55,309.77 162.17,302.69 205.78,299.15 286.57,281.46 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,270.84 59.14,313.31 67.66,345.15 78.88,348.69 84.81,341.61 96.95,338.07 105.59,323.92 125.55,306.23 162.17,302.69 205.78,302.69 286.57,274.38 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='255.81' x2='52.61' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='255.81' x2='56.72' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='255.81' x2='62.85' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='255.81' x2='73.63' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='255.81' x2='81.48' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='255.81' x2='90.72' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='255.81' x2='107.60' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='255.81' x2='108.15' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='255.81' x2='145.23' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='255.81' x2='181.92' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='255.81' x2='247.55' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='255.81' x2='351.08' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='255.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDI1NS44MXwzNTMuMTE=)'>
@@ -931,25 +939,33 @@
 <polyline points='386.20,333.95 714.52,333.95 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,304.46 714.52,304.46 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,274.97 714.52,274.97 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,353.11 426.71,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,353.11 490.68,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,353.11 554.65,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,353.11 618.63,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,353.11 682.60,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,353.11 453.54,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,353.11 568.61,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,353.11 683.67,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,348.69 714.52,348.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,319.20 714.52,319.20 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,289.72 714.52,289.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,260.23 714.52,260.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,353.11 394.72,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,353.11 458.70,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,353.11 522.67,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,353.11 586.64,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,353.11 650.61,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,277.92 407.54,336.89 420.30,348.69 433.40,348.69 446.28,348.69 460.03,342.79 472.27,336.89 495.87,313.31 549.84,277.92 600.94,277.92 699.60,260.23 699.60,277.92 600.94,283.82 549.84,307.41 495.87,348.69 472.27,348.69 460.03,348.69 446.28,348.69 433.40,348.69 420.30,348.69 407.54,348.69 401.13,325.10 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,277.92 407.54,336.89 420.30,348.69 433.40,348.69 446.28,348.69 460.03,342.79 472.27,336.89 495.87,313.31 549.84,277.92 600.94,277.92 699.60,260.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,277.92 600.94,283.82 549.84,307.41 495.87,348.69 472.27,348.69 460.03,348.69 446.28,348.69 433.40,348.69 420.30,348.69 407.54,348.69 401.13,325.10 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,307.41 407.54,342.79 420.30,348.69 433.40,348.69 446.28,348.69 460.03,348.69 472.27,348.69 495.87,333.95 549.84,289.72 600.94,277.92 699.60,277.92 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,283.82 407.54,348.69 420.30,348.69 433.40,348.69 446.28,348.69 460.03,348.69 472.27,348.69 495.87,336.89 549.84,301.51 600.94,277.92 699.60,266.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,353.11 396.01,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,353.11 511.07,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,353.11 626.14,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,277.92 407.54,336.89 419.01,348.69 430.79,348.69 442.38,348.69 454.74,342.79 465.75,336.89 486.97,313.31 535.51,277.92 581.46,277.92 670.19,260.23 670.19,277.92 581.46,283.82 535.51,307.41 486.97,348.69 465.75,348.69 454.74,348.69 442.38,348.69 430.79,348.69 419.01,348.69 407.54,348.69 401.77,325.10 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,277.92 407.54,336.89 419.01,348.69 430.79,348.69 442.38,348.69 454.74,342.79 465.75,336.89 486.97,313.31 535.51,277.92 581.46,277.92 670.19,260.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,277.92 581.46,283.82 535.51,307.41 486.97,348.69 465.75,348.69 454.74,348.69 442.38,348.69 430.79,348.69 419.01,348.69 407.54,348.69 401.77,325.10 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,307.41 407.54,342.79 419.01,348.69 430.79,348.69 442.38,348.69 454.74,348.69 465.75,348.69 486.97,333.95 535.51,289.72 581.46,277.92 670.19,277.92 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,283.82 407.54,348.69 419.01,348.69 430.79,348.69 442.38,348.69 454.74,348.69 465.75,348.69 486.97,336.89 535.51,301.51 581.46,277.92 670.19,266.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='255.81' x2='401.13' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='255.81' x2='404.21' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='255.81' x2='413.19' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='255.81' x2='424.42' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='255.81' x2='437.45' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='255.81' x2='447.43' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='255.81' x2='458.88' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='255.81' x2='473.88' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='255.81' x2='510.64' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='255.81' x2='556.67' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='255.81' x2='624.27' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='255.81' x2='699.60' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='255.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDI1NS44MXwzNTMuMTE=)'>
@@ -989,26 +1005,34 @@
 <polyline points='37.69,526.87 366.00,526.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,499.22 366.00,499.22 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,471.58 366.00,471.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,540.69 366.00,540.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,513.05 366.00,513.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,485.40 366.00,485.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,457.76 366.00,457.76 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,540.69 58.97,518.57 69.91,485.40 84.32,468.54 91.93,463.29 107.53,452.23 118.63,457.48 144.26,463.29 191.30,507.52 247.32,529.63 351.08,540.69 351.08,540.69 247.32,540.69 191.30,540.69 144.26,535.44 118.63,518.57 107.53,529.63 91.93,529.63 84.32,529.63 69.91,540.69 58.97,540.69 52.61,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,540.69 58.97,518.57 69.91,485.40 84.32,468.54 91.93,463.29 107.53,452.23 118.63,457.48 144.26,463.29 191.30,507.52 247.32,529.63 351.08,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,540.69 247.32,540.69 191.30,540.69 144.26,535.44 118.63,518.57 107.53,529.63 91.93,529.63 84.32,529.63 69.91,540.69 58.97,540.69 52.61,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,540.69 58.97,540.69 69.91,518.57 84.32,507.52 91.93,496.46 107.53,496.46 118.63,496.46 144.26,507.52 191.30,529.63 247.32,540.69 351.08,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,540.69 58.97,518.57 69.91,496.46 84.32,507.52 91.93,496.46 107.53,485.40 118.63,496.46 144.26,496.46 191.30,529.63 247.32,529.63 351.08,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,540.69 59.14,518.57 67.66,485.40 78.88,468.54 84.81,463.29 96.95,452.23 105.59,457.48 125.55,463.29 162.17,507.52 205.78,529.63 286.57,540.69 286.57,540.69 205.78,540.69 162.17,540.69 125.55,535.44 105.59,518.57 96.95,529.63 84.81,529.63 78.88,529.63 67.66,540.69 59.14,540.69 54.19,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,540.69 59.14,518.57 67.66,485.40 78.88,468.54 84.81,463.29 96.95,452.23 105.59,457.48 125.55,463.29 162.17,507.52 205.78,529.63 286.57,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,540.69 205.78,540.69 162.17,540.69 125.55,535.44 105.59,518.57 96.95,529.63 84.81,529.63 78.88,529.63 67.66,540.69 59.14,540.69 54.19,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,540.69 59.14,540.69 67.66,518.57 78.88,507.52 84.81,496.46 96.95,496.46 105.59,496.46 125.55,507.52 162.17,529.63 205.78,540.69 286.57,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,540.69 59.14,518.57 67.66,496.46 78.88,507.52 84.81,496.46 96.95,485.40 105.59,496.46 125.55,496.46 162.17,529.63 205.78,529.63 286.57,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='447.81' x2='52.61' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='447.81' x2='56.72' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='447.81' x2='62.85' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='447.81' x2='73.63' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='447.81' x2='81.48' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='447.81' x2='90.72' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='447.81' x2='107.60' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='447.81' x2='108.15' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='447.81' x2='145.23' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='447.81' x2='181.92' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='447.81' x2='247.55' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='447.81' x2='351.08' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='447.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDQ0Ny44MXw1NDUuMTE=)'>
@@ -1023,24 +1047,32 @@
 <polyline points='386.20,524.89 714.52,524.89 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,493.30 714.52,493.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,461.71 714.52,461.71 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,540.69 714.52,540.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,509.10 714.52,509.10 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,477.50 714.52,477.50 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,534.37 407.54,518.42 420.30,480.50 433.40,452.23 446.28,464.87 460.03,464.87 472.27,471.18 495.87,471.18 549.84,499.46 600.94,521.73 699.60,537.37 699.60,540.69 600.94,540.69 549.84,534.37 495.87,515.41 472.27,509.10 460.03,509.10 446.28,509.10 433.40,515.41 420.30,528.05 407.54,540.69 401.13,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,534.37 407.54,518.42 420.30,480.50 433.40,452.23 446.28,464.87 460.03,464.87 472.27,471.18 495.87,471.18 549.84,499.46 600.94,521.73 699.60,537.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,540.69 600.94,540.69 549.84,534.37 495.87,515.41 472.27,509.10 460.03,509.10 446.28,509.10 433.40,515.41 420.30,528.05 407.54,540.69 401.13,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,540.69 407.54,534.37 420.30,509.10 433.40,490.14 446.28,490.14 460.03,483.82 472.27,490.14 495.87,496.46 549.84,515.41 600.94,534.37 699.60,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,540.69 407.54,528.05 420.30,509.10 433.40,496.46 446.28,490.14 460.03,490.14 472.27,496.46 495.87,515.41 549.84,521.73 600.94,534.37 699.60,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,534.37 407.54,518.42 419.01,480.50 430.79,452.23 442.38,464.87 454.74,464.87 465.75,471.18 486.97,471.18 535.51,499.46 581.46,521.73 670.19,537.37 670.19,540.69 581.46,540.69 535.51,534.37 486.97,515.41 465.75,509.10 454.74,509.10 442.38,509.10 430.79,515.41 419.01,528.05 407.54,540.69 401.77,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,534.37 407.54,518.42 419.01,480.50 430.79,452.23 442.38,464.87 454.74,464.87 465.75,471.18 486.97,471.18 535.51,499.46 581.46,521.73 670.19,537.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,540.69 581.46,540.69 535.51,534.37 486.97,515.41 465.75,509.10 454.74,509.10 442.38,509.10 430.79,515.41 419.01,528.05 407.54,540.69 401.77,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,540.69 407.54,534.37 419.01,509.10 430.79,490.14 442.38,490.14 454.74,483.82 465.75,490.14 486.97,496.46 535.51,515.41 581.46,534.37 670.19,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,540.69 407.54,528.05 419.01,509.10 430.79,496.46 442.38,490.14 454.74,490.14 465.75,496.46 486.97,515.41 535.51,521.73 581.46,534.37 670.19,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='447.81' x2='401.13' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='447.81' x2='404.21' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='447.81' x2='413.19' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='447.81' x2='424.42' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='447.81' x2='437.45' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='447.81' x2='447.43' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='447.81' x2='458.88' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='447.81' x2='473.88' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='447.81' x2='510.64' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='447.81' x2='556.67' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='447.81' x2='624.27' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='447.81' x2='699.60' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='447.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDQ0Ny44MXw1NDUuMTE=)'>
@@ -1118,32 +1150,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,355.85 46.73,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,355.85 107.81,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,355.85 168.90,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,355.85 229.98,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,355.85 291.06,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,355.85 352.14,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,355.85 49.61,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,355.85 144.73,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,355.85 239.84,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,355.85 334.95,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,355.85 394.72,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,355.85 458.70,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,355.85 522.67,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,355.85 586.64,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,355.85 650.61,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,355.85 396.01,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,355.85 511.07,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,355.85 626.14,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
@@ -1170,32 +1194,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
@@ -2083,27 +2099,35 @@
 <polyline points='37.69,315.52 366.00,315.52 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,293.40 366.00,293.40 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,271.29 366.00,271.29 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,353.11 77.27,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,353.11 138.36,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,353.11 199.44,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,353.11 260.52,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,353.11 321.60,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,353.11 97.17,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,353.11 192.28,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,353.11 287.39,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,348.69 366.00,348.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,326.57 366.00,326.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,304.46 366.00,304.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,282.34 366.00,282.34 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,260.23 366.00,260.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,353.11 46.73,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,353.11 107.81,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,353.11 168.90,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,353.11 229.98,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,353.11 291.06,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,353.11 352.14,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,260.23 58.97,295.61 69.91,327.46 84.32,334.54 91.93,334.54 107.53,323.92 118.63,313.31 144.26,302.69 191.30,299.15 247.32,292.07 351.08,270.84 351.08,292.07 247.32,302.69 191.30,306.23 144.26,318.70 118.63,338.07 107.53,345.15 91.93,348.69 84.32,348.69 69.91,348.69 58.97,323.92 52.61,279.78 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,260.23 58.97,295.61 69.91,327.46 84.32,334.54 91.93,334.54 107.53,323.92 118.63,313.31 144.26,302.69 191.30,299.15 247.32,292.07 351.08,270.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,292.07 247.32,302.69 191.30,306.23 144.26,318.70 118.63,338.07 107.53,345.15 91.93,348.69 84.32,348.69 69.91,348.69 58.97,323.92 52.61,279.78 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,267.31 58.97,306.23 69.91,339.84 84.32,345.15 91.93,343.38 107.53,338.07 118.63,327.46 144.26,309.77 191.30,302.69 247.32,299.15 351.08,281.46 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,270.84 58.97,313.31 69.91,345.15 84.32,348.69 91.93,341.61 107.53,338.07 118.63,323.92 144.26,306.23 191.30,302.69 247.32,302.69 351.08,274.38 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,353.11 49.61,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,353.11 144.73,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,353.11 239.84,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,353.11 334.95,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,260.23 59.14,295.61 67.66,327.46 78.88,334.54 84.81,334.54 96.95,323.92 105.59,313.31 125.55,302.69 162.17,299.15 205.78,292.07 286.57,270.84 286.57,292.07 205.78,302.69 162.17,306.23 125.55,318.70 105.59,338.07 96.95,345.15 84.81,348.69 78.88,348.69 67.66,348.69 59.14,323.92 54.19,279.78 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,260.23 59.14,295.61 67.66,327.46 78.88,334.54 84.81,334.54 96.95,323.92 105.59,313.31 125.55,302.69 162.17,299.15 205.78,292.07 286.57,270.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,292.07 205.78,302.69 162.17,306.23 125.55,318.70 105.59,338.07 96.95,345.15 84.81,348.69 78.88,348.69 67.66,348.69 59.14,323.92 54.19,279.78 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,267.31 59.14,306.23 67.66,339.84 78.88,345.15 84.81,343.38 96.95,338.07 105.59,327.46 125.55,309.77 162.17,302.69 205.78,299.15 286.57,281.46 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,270.84 59.14,313.31 67.66,345.15 78.88,348.69 84.81,341.61 96.95,338.07 105.59,323.92 125.55,306.23 162.17,302.69 205.78,302.69 286.57,274.38 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='255.81' x2='52.61' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='255.81' x2='56.72' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='255.81' x2='62.85' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='255.81' x2='73.63' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='255.81' x2='81.48' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='255.81' x2='90.72' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='255.81' x2='107.60' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='255.81' x2='108.15' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='255.81' x2='145.23' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='255.81' x2='181.92' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='255.81' x2='247.55' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='255.81' x2='351.08' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='255.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDI1NS44MXwzNTMuMTE=)'>
@@ -2113,25 +2137,33 @@
 <polyline points='386.20,333.95 714.52,333.95 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,304.46 714.52,304.46 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,274.97 714.52,274.97 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,353.11 426.71,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,353.11 490.68,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,353.11 554.65,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,353.11 618.63,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,353.11 682.60,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,353.11 453.54,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,353.11 568.61,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,353.11 683.67,255.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,348.69 714.52,348.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,319.20 714.52,319.20 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,289.72 714.52,289.72 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,260.23 714.52,260.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,353.11 394.72,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,353.11 458.70,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,353.11 522.67,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,353.11 586.64,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,353.11 650.61,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,277.92 407.54,336.89 420.30,348.69 433.40,348.69 446.28,348.69 460.03,342.79 472.27,336.89 495.87,313.31 549.84,277.92 600.94,277.92 699.60,260.23 699.60,277.92 600.94,283.82 549.84,307.41 495.87,348.69 472.27,348.69 460.03,348.69 446.28,348.69 433.40,348.69 420.30,348.69 407.54,348.69 401.13,325.10 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,277.92 407.54,336.89 420.30,348.69 433.40,348.69 446.28,348.69 460.03,342.79 472.27,336.89 495.87,313.31 549.84,277.92 600.94,277.92 699.60,260.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,277.92 600.94,283.82 549.84,307.41 495.87,348.69 472.27,348.69 460.03,348.69 446.28,348.69 433.40,348.69 420.30,348.69 407.54,348.69 401.13,325.10 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,307.41 407.54,342.79 420.30,348.69 433.40,348.69 446.28,348.69 460.03,348.69 472.27,348.69 495.87,333.95 549.84,289.72 600.94,277.92 699.60,277.92 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,283.82 407.54,348.69 420.30,348.69 433.40,348.69 446.28,348.69 460.03,348.69 472.27,348.69 495.87,336.89 549.84,301.51 600.94,277.92 699.60,266.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,353.11 396.01,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,353.11 511.07,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,353.11 626.14,255.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,277.92 407.54,336.89 419.01,348.69 430.79,348.69 442.38,348.69 454.74,342.79 465.75,336.89 486.97,313.31 535.51,277.92 581.46,277.92 670.19,260.23 670.19,277.92 581.46,283.82 535.51,307.41 486.97,348.69 465.75,348.69 454.74,348.69 442.38,348.69 430.79,348.69 419.01,348.69 407.54,348.69 401.77,325.10 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,277.92 407.54,336.89 419.01,348.69 430.79,348.69 442.38,348.69 454.74,342.79 465.75,336.89 486.97,313.31 535.51,277.92 581.46,277.92 670.19,260.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,277.92 581.46,283.82 535.51,307.41 486.97,348.69 465.75,348.69 454.74,348.69 442.38,348.69 430.79,348.69 419.01,348.69 407.54,348.69 401.77,325.10 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,307.41 407.54,342.79 419.01,348.69 430.79,348.69 442.38,348.69 454.74,348.69 465.75,348.69 486.97,333.95 535.51,289.72 581.46,277.92 670.19,277.92 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,283.82 407.54,348.69 419.01,348.69 430.79,348.69 442.38,348.69 454.74,348.69 465.75,348.69 486.97,336.89 535.51,301.51 581.46,277.92 670.19,266.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='255.81' x2='401.13' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='255.81' x2='404.21' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='255.81' x2='413.19' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='255.81' x2='424.42' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='255.81' x2='437.45' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='255.81' x2='447.43' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='255.81' x2='458.88' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='255.81' x2='473.88' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='255.81' x2='510.64' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='255.81' x2='556.67' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='255.81' x2='624.27' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='255.81' x2='699.60' y2='258.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='255.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDI1NS44MXwzNTMuMTE=)'>
@@ -2161,26 +2193,34 @@
 <polyline points='37.69,526.87 366.00,526.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,499.22 366.00,499.22 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,471.58 366.00,471.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,540.69 366.00,540.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,513.05 366.00,513.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,485.40 366.00,485.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,457.76 366.00,457.76 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,540.69 58.97,518.57 69.91,485.40 84.32,468.54 91.93,463.29 107.53,452.23 118.63,457.48 144.26,463.29 191.30,507.52 247.32,529.63 351.08,540.69 351.08,540.69 247.32,540.69 191.30,540.69 144.26,535.44 118.63,518.57 107.53,529.63 91.93,529.63 84.32,529.63 69.91,540.69 58.97,540.69 52.61,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,540.69 58.97,518.57 69.91,485.40 84.32,468.54 91.93,463.29 107.53,452.23 118.63,457.48 144.26,463.29 191.30,507.52 247.32,529.63 351.08,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,540.69 247.32,540.69 191.30,540.69 144.26,535.44 118.63,518.57 107.53,529.63 91.93,529.63 84.32,529.63 69.91,540.69 58.97,540.69 52.61,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,540.69 58.97,540.69 69.91,518.57 84.32,507.52 91.93,496.46 107.53,496.46 118.63,496.46 144.26,507.52 191.30,529.63 247.32,540.69 351.08,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,540.69 58.97,518.57 69.91,496.46 84.32,507.52 91.93,496.46 107.53,485.40 118.63,496.46 144.26,496.46 191.30,529.63 247.32,529.63 351.08,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,540.69 59.14,518.57 67.66,485.40 78.88,468.54 84.81,463.29 96.95,452.23 105.59,457.48 125.55,463.29 162.17,507.52 205.78,529.63 286.57,540.69 286.57,540.69 205.78,540.69 162.17,540.69 125.55,535.44 105.59,518.57 96.95,529.63 84.81,529.63 78.88,529.63 67.66,540.69 59.14,540.69 54.19,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,540.69 59.14,518.57 67.66,485.40 78.88,468.54 84.81,463.29 96.95,452.23 105.59,457.48 125.55,463.29 162.17,507.52 205.78,529.63 286.57,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,540.69 205.78,540.69 162.17,540.69 125.55,535.44 105.59,518.57 96.95,529.63 84.81,529.63 78.88,529.63 67.66,540.69 59.14,540.69 54.19,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,540.69 59.14,540.69 67.66,518.57 78.88,507.52 84.81,496.46 96.95,496.46 105.59,496.46 125.55,507.52 162.17,529.63 205.78,540.69 286.57,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,540.69 59.14,518.57 67.66,496.46 78.88,507.52 84.81,496.46 96.95,485.40 105.59,496.46 125.55,496.46 162.17,529.63 205.78,529.63 286.57,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='447.81' x2='52.61' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='447.81' x2='56.72' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='447.81' x2='62.85' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='447.81' x2='73.63' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='447.81' x2='81.48' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='447.81' x2='90.72' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='447.81' x2='107.60' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='447.81' x2='108.15' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='447.81' x2='145.23' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='447.81' x2='181.92' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='447.81' x2='247.55' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='447.81' x2='351.08' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='447.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDQ0Ny44MXw1NDUuMTE=)'>
@@ -2190,24 +2230,32 @@
 <polyline points='386.20,524.89 714.52,524.89 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,493.30 714.52,493.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,461.71 714.52,461.71 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,447.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,540.69 714.52,540.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,509.10 714.52,509.10 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,477.50 714.52,477.50 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,534.37 407.54,518.42 420.30,480.50 433.40,452.23 446.28,464.87 460.03,464.87 472.27,471.18 495.87,471.18 549.84,499.46 600.94,521.73 699.60,537.37 699.60,540.69 600.94,540.69 549.84,534.37 495.87,515.41 472.27,509.10 460.03,509.10 446.28,509.10 433.40,515.41 420.30,528.05 407.54,540.69 401.13,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,534.37 407.54,518.42 420.30,480.50 433.40,452.23 446.28,464.87 460.03,464.87 472.27,471.18 495.87,471.18 549.84,499.46 600.94,521.73 699.60,537.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,540.69 600.94,540.69 549.84,534.37 495.87,515.41 472.27,509.10 460.03,509.10 446.28,509.10 433.40,515.41 420.30,528.05 407.54,540.69 401.13,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,540.69 407.54,534.37 420.30,509.10 433.40,490.14 446.28,490.14 460.03,483.82 472.27,490.14 495.87,496.46 549.84,515.41 600.94,534.37 699.60,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,540.69 407.54,528.05 420.30,509.10 433.40,496.46 446.28,490.14 460.03,490.14 472.27,496.46 495.87,515.41 549.84,521.73 600.94,534.37 699.60,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,447.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,534.37 407.54,518.42 419.01,480.50 430.79,452.23 442.38,464.87 454.74,464.87 465.75,471.18 486.97,471.18 535.51,499.46 581.46,521.73 670.19,537.37 670.19,540.69 581.46,540.69 535.51,534.37 486.97,515.41 465.75,509.10 454.74,509.10 442.38,509.10 430.79,515.41 419.01,528.05 407.54,540.69 401.77,540.69 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,534.37 407.54,518.42 419.01,480.50 430.79,452.23 442.38,464.87 454.74,464.87 465.75,471.18 486.97,471.18 535.51,499.46 581.46,521.73 670.19,537.37 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,540.69 581.46,540.69 535.51,534.37 486.97,515.41 465.75,509.10 454.74,509.10 442.38,509.10 430.79,515.41 419.01,528.05 407.54,540.69 401.77,540.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,540.69 407.54,534.37 419.01,509.10 430.79,490.14 442.38,490.14 454.74,483.82 465.75,490.14 486.97,496.46 535.51,515.41 581.46,534.37 670.19,540.69 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,540.69 407.54,528.05 419.01,509.10 430.79,496.46 442.38,490.14 454.74,490.14 465.75,496.46 486.97,515.41 535.51,521.73 581.46,534.37 670.19,540.69 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='447.81' x2='401.13' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='447.81' x2='404.21' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='447.81' x2='413.19' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='447.81' x2='424.42' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='447.81' x2='437.45' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='447.81' x2='447.43' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='447.81' x2='458.88' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='447.81' x2='473.88' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='447.81' x2='510.64' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='447.81' x2='556.67' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='447.81' x2='624.27' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='447.81' x2='699.60' y2='450.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='447.81' width='328.32' height='97.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDQ0Ny44MXw1NDUuMTE=)'>
@@ -2270,32 +2318,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,355.85 46.73,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,355.85 107.81,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,355.85 168.90,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,355.85 229.98,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,355.85 291.06,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,355.85 352.14,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,355.85 49.61,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,355.85 144.73,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,355.85 239.84,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,355.85 334.95,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,355.85 394.72,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,355.85 458.70,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,355.85 522.67,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,355.85 586.64,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,355.85 650.61,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,355.85 396.01,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,355.85 511.07,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,355.85 626.14,353.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='364.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1My4xMXwzODQuMDA=)'>
 </g>
@@ -2317,32 +2357,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/plot/censored-plot-with-bql.svg
+++ b/tests/testthat/_snaps/plot/censored-plot-with-bql.svg
@@ -768,27 +768,35 @@
 <polyline points='37.69,470.43 366.00,470.43 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,426.49 366.00,426.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,382.56 366.00,382.56 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,536.33 366.00,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,492.39 366.00,492.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,448.46 366.00,448.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,404.53 366.00,404.53 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,360.59 366.00,360.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,360.59 58.97,430.89 69.91,494.15 84.32,508.21 91.93,508.21 107.53,487.12 118.63,466.03 144.26,444.94 191.30,437.91 247.32,423.86 351.08,381.68 351.08,423.86 247.32,444.94 191.30,451.97 144.26,476.75 118.63,515.24 107.53,529.30 91.93,536.33 84.32,536.33 69.91,536.33 58.97,487.12 52.61,399.43 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,360.59 58.97,430.89 69.91,494.15 84.32,508.21 91.93,508.21 107.53,487.12 118.63,466.03 144.26,444.94 191.30,437.91 247.32,423.86 351.08,381.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,423.86 247.32,444.94 191.30,451.97 144.26,476.75 118.63,515.24 107.53,529.30 91.93,536.33 84.32,536.33 69.91,536.33 58.97,487.12 52.61,399.43 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,374.65 58.97,451.97 69.91,518.75 84.32,529.30 91.93,525.78 107.53,515.24 118.63,494.15 144.26,459.00 191.30,444.94 247.32,437.91 351.08,402.77 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,381.68 58.97,466.03 69.91,529.30 84.32,536.33 91.93,522.27 107.53,515.24 118.63,487.12 144.26,451.97 191.30,444.94 247.32,444.94 351.08,388.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,360.59 59.14,430.89 67.66,494.15 78.88,508.21 84.81,508.21 96.95,487.12 105.59,466.03 125.55,444.94 162.17,437.91 205.78,423.86 286.57,381.68 286.57,423.86 205.78,444.94 162.17,451.97 125.55,476.75 105.59,515.24 96.95,529.30 84.81,536.33 78.88,536.33 67.66,536.33 59.14,487.12 54.19,399.43 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,360.59 59.14,430.89 67.66,494.15 78.88,508.21 84.81,508.21 96.95,487.12 105.59,466.03 125.55,444.94 162.17,437.91 205.78,423.86 286.57,381.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,423.86 205.78,444.94 162.17,451.97 125.55,476.75 105.59,515.24 96.95,529.30 84.81,536.33 78.88,536.33 67.66,536.33 59.14,487.12 54.19,399.43 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,374.65 59.14,451.97 67.66,518.75 78.88,529.30 84.81,525.78 96.95,515.24 105.59,494.15 125.55,459.00 162.17,444.94 205.78,437.91 286.57,402.77 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,381.68 59.14,466.03 67.66,529.30 78.88,536.33 84.81,522.27 96.95,515.24 105.59,487.12 125.55,451.97 162.17,444.94 205.78,444.94 286.57,388.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='351.81' x2='52.61' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='351.81' x2='56.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='351.81' x2='62.85' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='351.81' x2='73.63' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='351.81' x2='81.48' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='351.81' x2='90.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='351.81' x2='107.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='351.81' x2='108.15' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='351.81' x2='145.23' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='351.81' x2='181.92' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='351.81' x2='247.55' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='351.81' x2='351.08' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -803,25 +811,33 @@
 <polyline points='386.20,507.04 714.52,507.04 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,448.46 714.52,448.46 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,389.88 714.52,389.88 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,536.33 714.52,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,477.75 714.52,477.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,419.17 714.52,419.17 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,360.59 714.52,360.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,395.74 407.54,512.89 420.30,536.33 433.40,536.33 446.28,536.33 460.03,524.61 472.27,512.89 495.87,466.03 549.84,395.74 600.94,395.74 699.60,360.59 699.60,395.74 600.94,407.45 549.84,454.32 495.87,536.33 472.27,536.33 460.03,536.33 446.28,536.33 433.40,536.33 420.30,536.33 407.54,536.33 401.13,489.46 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,395.74 407.54,512.89 420.30,536.33 433.40,536.33 446.28,536.33 460.03,524.61 472.27,512.89 495.87,466.03 549.84,395.74 600.94,395.74 699.60,360.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,395.74 600.94,407.45 549.84,454.32 495.87,536.33 472.27,536.33 460.03,536.33 446.28,536.33 433.40,536.33 420.30,536.33 407.54,536.33 401.13,489.46 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,454.32 407.54,524.61 420.30,536.33 433.40,536.33 446.28,536.33 460.03,536.33 472.27,536.33 495.87,507.04 549.84,419.17 600.94,395.74 699.60,395.74 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,407.45 407.54,536.33 420.30,536.33 433.40,536.33 446.28,536.33 460.03,536.33 472.27,536.33 495.87,512.89 549.84,442.60 600.94,395.74 699.60,372.31 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,395.74 407.54,512.89 419.01,536.33 430.79,536.33 442.38,536.33 454.74,524.61 465.75,512.89 486.97,466.03 535.51,395.74 581.46,395.74 670.19,360.59 670.19,395.74 581.46,407.45 535.51,454.32 486.97,536.33 465.75,536.33 454.74,536.33 442.38,536.33 430.79,536.33 419.01,536.33 407.54,536.33 401.77,489.46 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,395.74 407.54,512.89 419.01,536.33 430.79,536.33 442.38,536.33 454.74,524.61 465.75,512.89 486.97,466.03 535.51,395.74 581.46,395.74 670.19,360.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,395.74 581.46,407.45 535.51,454.32 486.97,536.33 465.75,536.33 454.74,536.33 442.38,536.33 430.79,536.33 419.01,536.33 407.54,536.33 401.77,489.46 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,454.32 407.54,524.61 419.01,536.33 430.79,536.33 442.38,536.33 454.74,536.33 465.75,536.33 486.97,507.04 535.51,419.17 581.46,395.74 670.19,395.74 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,407.45 407.54,536.33 419.01,536.33 430.79,536.33 442.38,536.33 454.74,536.33 465.75,536.33 486.97,512.89 535.51,442.60 581.46,395.74 670.19,372.31 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='351.81' x2='401.13' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='351.81' x2='404.21' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='351.81' x2='413.19' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='351.81' x2='424.42' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='351.81' x2='437.45' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='351.81' x2='447.43' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='351.81' x2='458.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='351.81' x2='473.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='351.81' x2='510.64' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='351.81' x2='556.67' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='351.81' x2='624.27' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='351.81' x2='699.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -901,32 +917,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
@@ -1682,27 +1690,35 @@
 <polyline points='37.69,470.43 366.00,470.43 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,426.49 366.00,426.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,382.56 366.00,382.56 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='77.27,545.11 77.27,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='138.36,545.11 138.36,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='199.44,545.11 199.44,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='260.52,545.11 260.52,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='321.60,545.11 321.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='97.17,545.11 97.17,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='192.28,545.11 192.28,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='287.39,545.11 287.39,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,536.33 366.00,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,492.39 366.00,492.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,448.46 366.00,448.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,404.53 366.00,404.53 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='37.69,360.59 366.00,360.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.73,545.11 46.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.81,545.11 107.81,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.90,545.11 168.90,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='229.98,545.11 229.98,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='291.06,545.11 291.06,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='352.14,545.11 352.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='52.61,360.59 58.97,430.89 69.91,494.15 84.32,508.21 91.93,508.21 107.53,487.12 118.63,466.03 144.26,444.94 191.30,437.91 247.32,423.86 351.08,381.68 351.08,423.86 247.32,444.94 191.30,451.97 144.26,476.75 118.63,515.24 107.53,529.30 91.93,536.33 84.32,536.33 69.91,536.33 58.97,487.12 52.61,399.43 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='52.61,360.59 58.97,430.89 69.91,494.15 84.32,508.21 91.93,508.21 107.53,487.12 118.63,466.03 144.26,444.94 191.30,437.91 247.32,423.86 351.08,381.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='351.08,423.86 247.32,444.94 191.30,451.97 144.26,476.75 118.63,515.24 107.53,529.30 91.93,536.33 84.32,536.33 69.91,536.33 58.97,487.12 52.61,399.43 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='52.61,374.65 58.97,451.97 69.91,518.75 84.32,529.30 91.93,525.78 107.53,515.24 118.63,494.15 144.26,459.00 191.30,444.94 247.32,437.91 351.08,402.77 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='52.61,381.68 58.97,466.03 69.91,529.30 84.32,536.33 91.93,522.27 107.53,515.24 118.63,487.12 144.26,451.97 191.30,444.94 247.32,444.94 351.08,388.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='49.61,545.11 49.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.73,545.11 144.73,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='239.84,545.11 239.84,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.95,545.11 334.95,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='54.19,360.59 59.14,430.89 67.66,494.15 78.88,508.21 84.81,508.21 96.95,487.12 105.59,466.03 125.55,444.94 162.17,437.91 205.78,423.86 286.57,381.68 286.57,423.86 205.78,444.94 162.17,451.97 125.55,476.75 105.59,515.24 96.95,529.30 84.81,536.33 78.88,536.33 67.66,536.33 59.14,487.12 54.19,399.43 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='54.19,360.59 59.14,430.89 67.66,494.15 78.88,508.21 84.81,508.21 96.95,487.12 105.59,466.03 125.55,444.94 162.17,437.91 205.78,423.86 286.57,381.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='286.57,423.86 205.78,444.94 162.17,451.97 125.55,476.75 105.59,515.24 96.95,529.30 84.81,536.33 78.88,536.33 67.66,536.33 59.14,487.12 54.19,399.43 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='54.19,374.65 59.14,451.97 67.66,518.75 78.88,529.30 84.81,525.78 96.95,515.24 105.59,494.15 125.55,459.00 162.17,444.94 205.78,437.91 286.57,402.77 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='54.19,381.68 59.14,466.03 67.66,529.30 78.88,536.33 84.81,522.27 96.95,515.24 105.59,487.12 125.55,451.97 162.17,444.94 205.78,444.94 286.57,388.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='52.61' y1='351.81' x2='52.61' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='56.72' y1='351.81' x2='56.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='62.85' y1='351.81' x2='62.85' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='73.63' y1='351.81' x2='73.63' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='81.48' y1='351.81' x2='81.48' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='90.72' y1='351.81' x2='90.72' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='107.60' y1='351.81' x2='107.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='108.15' y1='351.81' x2='108.15' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='145.23' y1='351.81' x2='145.23' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='181.92' y1='351.81' x2='181.92' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='247.55' y1='351.81' x2='247.55' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='351.08' y1='351.81' x2='351.08' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='37.69' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -1712,25 +1728,33 @@
 <polyline points='386.20,507.04 714.52,507.04 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,448.46 714.52,448.46 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,389.88 714.52,389.88 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='426.71,545.11 426.71,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='490.68,545.11 490.68,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='554.65,545.11 554.65,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='618.63,545.11 618.63,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='682.60,545.11 682.60,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.54,545.11 453.54,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='568.61,545.11 568.61,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='683.67,545.11 683.67,351.81 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,536.33 714.52,536.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,477.75 714.52,477.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,419.17 714.52,419.17 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='386.20,360.59 714.52,360.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='394.72,545.11 394.72,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='458.70,545.11 458.70,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.67,545.11 522.67,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='586.64,545.11 586.64,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='650.61,545.11 650.61,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='401.13,395.74 407.54,512.89 420.30,536.33 433.40,536.33 446.28,536.33 460.03,524.61 472.27,512.89 495.87,466.03 549.84,395.74 600.94,395.74 699.60,360.59 699.60,395.74 600.94,407.45 549.84,454.32 495.87,536.33 472.27,536.33 460.03,536.33 446.28,536.33 433.40,536.33 420.30,536.33 407.54,536.33 401.13,489.46 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
-<polyline points='401.13,395.74 407.54,512.89 420.30,536.33 433.40,536.33 446.28,536.33 460.03,524.61 472.27,512.89 495.87,466.03 549.84,395.74 600.94,395.74 699.60,360.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='699.60,395.74 600.94,407.45 549.84,454.32 495.87,536.33 472.27,536.33 460.03,536.33 446.28,536.33 433.40,536.33 420.30,536.33 407.54,536.33 401.13,489.46 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='401.13,454.32 407.54,524.61 420.30,536.33 433.40,536.33 446.28,536.33 460.03,536.33 472.27,536.33 495.87,507.04 549.84,419.17 600.94,395.74 699.60,395.74 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
-<polyline points='401.13,407.45 407.54,536.33 420.30,536.33 433.40,536.33 446.28,536.33 460.03,536.33 472.27,536.33 495.87,512.89 549.84,442.60 600.94,395.74 699.60,372.31 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='396.01,545.11 396.01,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='511.07,545.11 511.07,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='626.14,545.11 626.14,351.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polygon points='401.77,395.74 407.54,512.89 419.01,536.33 430.79,536.33 442.38,536.33 454.74,524.61 465.75,512.89 486.97,466.03 535.51,395.74 581.46,395.74 670.19,360.59 670.19,395.74 581.46,407.45 535.51,454.32 486.97,536.33 465.75,536.33 454.74,536.33 442.38,536.33 430.79,536.33 419.01,536.33 407.54,536.33 401.77,489.46 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #FF0000; fill-opacity: 0.20;' />
+<polyline points='401.77,395.74 407.54,512.89 419.01,536.33 430.79,536.33 442.38,536.33 454.74,524.61 465.75,512.89 486.97,466.03 535.51,395.74 581.46,395.74 670.19,360.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='670.19,395.74 581.46,407.45 535.51,454.32 486.97,536.33 465.75,536.33 454.74,536.33 442.38,536.33 430.79,536.33 419.01,536.33 407.54,536.33 401.77,489.46 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='401.77,454.32 407.54,524.61 419.01,536.33 430.79,536.33 442.38,536.33 454.74,536.33 465.75,536.33 486.97,507.04 535.51,419.17 581.46,395.74 670.19,395.74 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' />
+<polyline points='401.77,407.45 407.54,536.33 419.01,536.33 430.79,536.33 442.38,536.33 454.74,536.33 465.75,536.33 486.97,512.89 535.51,442.60 581.46,395.74 670.19,372.31 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='401.13' y1='351.81' x2='401.13' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='404.21' y1='351.81' x2='404.21' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='413.19' y1='351.81' x2='413.19' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='424.42' y1='351.81' x2='424.42' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='437.45' y1='351.81' x2='437.45' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='447.43' y1='351.81' x2='447.43' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='458.88' y1='351.81' x2='458.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='473.88' y1='351.81' x2='473.88' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='510.64' y1='351.81' x2='510.64' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='556.67' y1='351.81' x2='556.67' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='624.27' y1='351.81' x2='624.27' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<line x1='699.60' y1='351.81' x2='699.60' y2='357.60' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
 <rect x='386.20' y='351.81' width='328.32' height='193.31' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDM1MS44MXw1NDUuMTE=)'>
@@ -1795,32 +1819,24 @@
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='46.73,547.85 46.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='107.81,547.85 107.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='229.98,547.85 229.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='291.06,547.85 291.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='352.14,547.85 352.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='107.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='229.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='291.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text x='352.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.61,547.85 49.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.73,547.85 144.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.84,547.85 239.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.95,547.85 334.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='144.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='239.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='334.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='394.72,547.85 394.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='458.70,547.85 458.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='522.67,547.85 522.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.64,547.85 586.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='650.61,547.85 650.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='394.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='458.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='522.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text x='586.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text x='650.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<polyline points='396.01,547.85 396.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='511.07,547.85 511.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='626.14,547.85 626.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='396.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='626.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
 </g>
 <g clip-path='url(#cpMzcuNjl8NzE0LjUyfDU0NS4xMXw1NzYuMDA=)'>
 </g>


### PR DESCRIPTION
This PR ensures that the xaxis of the pctblq / pctalq plots is of the same scale as the main vpc plot. Both plots use mid point of bin interval for the x axis, however previously, when `show.points = TRUE` and/or `show.boundaries = TRUE`, the xaxis scale for the censored plot did not account for the xaxis rescaling in the primary vpc plot, it now does. Attn @smouksassi