### PR TITLE
prepare version 1.5.1 for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,15 @@
 Package: tidyvpc
 Type: Package
 Title: VPC Percentiles and Prediction Intervals
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: c(
       person("Olivier", "Barriere", email = "olivier.barriere@gmail.com",
       role = c("aut")),
       person("Benjamin", "Rich", email = "mail@benjaminrich.net",
       role = c("aut")),
       person("James", "Craig", email = "james.craig@certara.com",
-      role = c("aut", "cre")),
+      role = c("aut", "cre"),
+      comment = c(ORCID = "0000-0003-1757-9234")),
       person("Samer", "Mouksassi", email = "samermouksassi@gmail.com",
       role = c("aut")),
       person("Bill", "Denney", email="wdenney@humanpredictions.com", 
@@ -37,13 +38,13 @@ Imports:
     methods,
     mgcv,
     classInt,
+    cluster,
     ggplot2,
     stats,
     fastDummies,
     utils,
     egg
 Suggests:
-    cluster,
     dplyr,
     KernSmooth,
     knitr,

--- a/R/vpcstats.R
+++ b/R/vpcstats.R
@@ -358,7 +358,7 @@ stratify.tidyvpcobj <- function(o, formula, data=o$data, ...) {
 #'     simulated(sim_data, y=DV) %>%
 #'     stratify(~ GENDER) %>%
 #'     binning(stratum = list(GENDER = "M"), bin = "jenks", nbins = 5, by.strata = TRUE) %>%
-#'     binning(stratum = list(GENDER = "F"), bin = "pam", nbins = 4, by.strata = TRUE) %>%
+#'     binning(stratum = list(GENDER = "F"), bin = "kmeans", nbins = 4, by.strata = TRUE) %>%
 #'     vpcstats()
 #'
 #'  # Binning Categorical DV using rounded time variable
@@ -763,10 +763,8 @@ bininfo.tidyvpcobj <- function(o, by.strata=o$bin.by.strata, ...) {
 #' bin_by_eqcut(nbins=4)(x)
 #' bin_by_ntile(nbins=4)(x)
 #'
-#' \donttest{
 #' bin_by_pam(nbins=4)(x)
 #' bin_by_classInt("pretty", nbins=4)(x)
-#' }
 #'
 #' @name binningfunctions
 NULL

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Release summary
 
-This is a minor release `1.5.0` that provides misc usability enhancements, including the ability to plot percentage of BLQ and/or ALQ in `plot.tidyvpcobj` if `censoring()` is used, support for `binning()` either before or after usage of `predcorrect()`, and additional validation checks within `predcorrect()` and `simulated()` functions to identify potential issues within data.
+This is a patch release `1.5.1` that ensures unit tests do not fail when env var `_R_CHECK_DEPENDS_ONLY_=true` in `R CMD check`. As a result, the `cluster` dependency has been moved from `Suggests` to `Imports`.
 
 ## Test environments
 

--- a/man/binning.Rd
+++ b/man/binning.Rd
@@ -78,7 +78,7 @@ vpc <- observed(obs_data, x=TIME, y=DV) \%>\%
     simulated(sim_data, y=DV) \%>\%
     stratify(~ GENDER) \%>\%
     binning(stratum = list(GENDER = "M"), bin = "jenks", nbins = 5, by.strata = TRUE) \%>\%
-    binning(stratum = list(GENDER = "F"), bin = "pam", nbins = 4, by.strata = TRUE) \%>\%
+    binning(stratum = list(GENDER = "F"), bin = "kmeans", nbins = 4, by.strata = TRUE) \%>\%
     vpcstats()
 
  # Binning Categorical DV using rounded time variable

--- a/man/binningfunctions.Rd
+++ b/man/binningfunctions.Rd
@@ -50,9 +50,7 @@ cut_at(breaks)(x)
 bin_by_eqcut(nbins=4)(x)
 bin_by_ntile(nbins=4)(x)
 
-\donttest{
 bin_by_pam(nbins=4)(x)
 bin_by_classInt("pretty", nbins=4)(x)
-}
 
 }

--- a/tests/testthat/test-binning.R
+++ b/tests/testthat/test-binning.R
@@ -72,7 +72,6 @@ test_that("cat obs strat vpcstats is correct", {
 })
 
 test_that("binning methods are valid", {
-
   ## Subest MDV = 0
   obs <- obs_data[MDV == 0]
   sim <- sim_data[MDV == 0]


### PR DESCRIPTION
This is a patch release `1.5.1` that ensures unit tests do not fail when env var `_R_CHECK_DEPENDS_ONLY_=true` in `R CMD check`. As a result, the `cluster` dependency has been moved from `Suggests` to `Imports`.