### PR TITLE
DRWN-1503 non replicate support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidyvpc
 Type: Package
 Title: VPC Percentiles and Prediction Intervals
-Version: 1.5.2
+Version: 1.6.0
 Authors@R: c(
       person("Olivier", "Barriere", email = "olivier.barriere@gmail.com",
       role = c("aut")),

--- a/R/binless.R
+++ b/R/binless.R
@@ -218,8 +218,12 @@ binlessfit <- function(o, conf.level = .95, llam.quant = NULL, span = NULL, ...)
     strat.split <- split(obs, strat)
     strat.split <- strat.split[lapply(strat.split,NROW)>0]
     x.strat <- c("x", names(strat))
-    sim.strat <- sim[, c(names(strat)) := rep(strat, len = .N), by = .(repl)]
-    strat.split.sim <- split(sim, strat)
+    if (o$replicate) {
+      sim.strat <- sim[, c(names(strat)) := rep(strat, len = .N), by = .(repl)]
+      strat.split.sim <- split(sim, strat)
+    } else {
+      strat.split.sim <- split(sim, o$strat.sim)
+    }
     strat.split.sim <- strat.split.sim[lapply(strat.split.sim,NROW)>0]
   }
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -272,9 +272,19 @@ plot_continuous <-
           alpha = ribbon.alpha,
           col = NA
         ) +
-        ggplot2::geom_line(ggplot2::aes(y = md, col = qname, group = qname)) +
-        ggplot2::geom_line(ggplot2::aes(y = y, linetype = qname), linewidth =
-                             1) +
+        ggplot2::geom_line(ggplot2::aes(y = md, col = qname, group = qname))
+      
+      if (method == "binless" && !vpc$replicate) {
+        g <-
+          g + ggplot2::geom_line(
+            ggplot2::aes(y = fit, linetype = qname),
+            linewidth = 1,
+            data = vpc$rqss.obs.fits
+          )
+      } else {
+        g <- g + ggplot2::geom_line(ggplot2::aes(y = y, linetype = qname), linewidth = 1)
+      }
+       g <- g +
         ggplot2::scale_colour_manual(
           name = sprintf(
             "Simulated Percentiles\nMedian (lines) %s%% CI (areas)",

--- a/R/vpcstats.R
+++ b/R/vpcstats.R
@@ -81,7 +81,8 @@ observed.data.frame <- function(o, x, yobs, pred=NULL, blq=NULL, lloq=-Inf, alq=
 #' @param o A \code{tidyvpcobj}.
 #' @param data A \code{data.frame} of simulated data.
 #' @param ysim Numeric y-variable, typically named DV.
-#' @param xsim Numeric x-variable, typically named TIME.
+#' @param xsim Numeric x-variable, typically named TIME. This argument is not required, see details below.
+#' @param repl Numeric replicate variable, typically named REPL. This argument is not required, see details below.
 #' @param ... Other arguments.
 #' @return A \code{tidyvpcobj} containing simulated dataset \code{sim} formatted with columns \code{x}, \code{y}, and \code{repl}, which indicates the replicate number.
 #'  The column \code{x} is used from the \code{observed()} function. Resulting dataset is of class \code{data.frame} and \code{data.table}.
@@ -98,27 +99,50 @@ simulated <- function(o, ...) UseMethod("simulated")
 
 #' @rdname simulated
 #' @export
-simulated.tidyvpcobj <- function(o, data, ysim, ..., xsim) {
+simulated.tidyvpcobj <- function(o, data, ysim, xsim, repl, ...) {
   ysim <- rlang::eval_tidy(rlang::enquo(ysim), data)
   obs  <- o$obs
   nrep <- length(ysim)/nrow(obs)
+  replicate <- TRUE
+  
   if (nrep != as.integer(nrep)) {
-    stop("The number of simulated rows is not a multiple of the number of observed rows.  Ensure that you filtered your observed data to remove MDV rows.")
+    .message(
+      "The number of simulated rows is not a multiple of the number of observed rows."
+    )
+    replicate <- FALSE
   }
-  repl <- rep(seq_len(nrep), each=nrow(obs))
+  
+  if (!replicate && (missing(xsim) || missing(repl))) {
+    warning("The simulated data is not a replicate of the observed data. Ensure that you filtered your observed data to remove MDV rows. If this is intentional, use the `xsim` and `repl` arguments for non-replicate support.")
+  }
+  
   if (!missing(xsim)) {
     xsim <- rlang::eval_tidy(rlang::enquo(xsim), data)
+    .message("Using user-supplied x-values from `xsim`.")
     # generate a replication vector to confirm time matching
     xrep_vec <- rep(seq_along(obs$x), nrep)
-    if (!all(xsim == obs$x[xrep_vec])) {
-      stop("Values of `xsim` do not match observed data x-values.  Ensure that you filtered your observed data to remove MDV rows.")
-    }
+    if (length(xsim) == length(xrep_vec) && !all(xsim == obs$x[xrep_vec])) {
+      warning("Values of `xsim` do not match observed data x-values.")
+      replicate <- FALSE
+    } 
   } else {
     xsim <- obs$x
+    .message(
+      "No `xsim` argument specified, repeating the x-values from observed data, for each replicate of simulated data."
+    )
   }
+  
+  if (!missing(repl)) {
+    repl <- rlang::eval_tidy(rlang::enquo(repl), data)
+    .message("Using user-supplied replicate values from `repl`.")
+  } else {
+    repl <- rep(seq_len(nrep), each=nrow(obs))
+    .message("No `repl` argument provided; replicate IDs automatically generated from the total number of simulated rows.")
+  }
+  
 
   sim <- data.table(x=xsim, y=ysim, repl)
-  update(o, sim=sim)
+  update(o, sim=sim, replicate=replicate)
 }
 
 #' Censoring observed data for Visual Predictive Check (VPC)
@@ -278,10 +302,23 @@ stratify <- function(o, ...) UseMethod("stratify")
 #' @method stratify tidyvpcobj
 #' @rdname stratify
 #' @export
-stratify.tidyvpcobj <- function(o, formula, data=o$data, ...) {
+stratify.tidyvpcobj <- function(o, formula, data=o$data, data.sim = NULL, ...) {
   if (!inherits(formula, "formula")) {
     stop("Expecting a formula")
   }
+  if (!is.null(data.sim)) {
+    if (!o$replicate) {
+      .message("Obs/Sim are non replicates - cannot recycle strata from observed data in simulated data.")
+      .message("Expecting simulated data in `data` argument. Note, for observed
+            data, strata will be automatically extracted from o$data and cannot be overridden.")
+      if (nrow(data.sim) == nrow(o$data)) {
+        stop("Expecting simulated data in `data` argument")
+      }
+    } else {
+      warning("Ignoring `data.sim` argument, obs/sim are replicates.")
+    }
+  }
+  
   flist <- as.list(formula)
   if (length(flist) == 3) {
     lhs <- as.call(c(flist[[1]], flist[[2]]))
@@ -316,13 +353,19 @@ stratify.tidyvpcobj <- function(o, formula, data=o$data, ...) {
   strat.split <- split(o$obs, strat)
 
   strat.split <- strat.split[lapply(strat.split,NROW)>0]
-
-  update(o, strat=strat, strat.split = strat.split, strat.formula=formula)
+  # Likely do not need to split for simulated data, only required for binless
+  if (!o$replicate && !is.null(data.sim)) {
+    strat.sim <- as.data.table(model.frame(formula, data.sim))
+    o$sim[, names(strat.sim) := strat.sim]
+  } else {
+    strat.sim <- NULL
+  }
+  update(o, strat=strat, strat.split = strat.split, strat.sim = strat.sim,  strat.formula=formula)
 }
 
 #' Binning methods for Visual Predictive Check (VPC)
 #'
-#' This function executes binning methods available in classInt i.e. "jenks", "kmeans", "sd", "pretty", "pam", "kmeans", "hclust", "bclust", "fisher", "dpih", "box", "headtails", and "maximum".
+#' This function executes binning methods available in classInt e.g., "jenks", "kmeans", "sd", "pretty", "pam", "kmeans", "hclust", "bclust", "fisher", "dpih", "box", "headtails", and "maximum".
 #' You may also bin directly on x-variable or alternatively specify "centers" or "breaks". For explanation of binning methods see \code{\link[classInt]{classIntervals}}.
 #'
 #' @param o A \code{tidyvpcobj}.
@@ -522,7 +565,32 @@ binning.tidyvpcobj <- function(o, bin, data=o$data, xbin="xmedian", centers, bre
     stratbin <- data.table(bin)
   }
   o <- update(o, .stratbin=stratbin, bin.by.strata=by.strata)
-
+  
+  
+  # Non-replicate support - merge bins from observed data into sim
+  if (!o$replicate) {
+    # Get unique bin intervals  
+    bin_intervals <- bininfo(o)
+      # Add columns for lower and upper bounds to bin_intervals
+      bin_intervals[, c("lower", "upper") := tstrsplit(gsub("[\\[\\]()]", "", bin, perl = TRUE), ",", fixed = TRUE)]
+      bin_intervals[, c("lower", "upper") := .(as.numeric(lower), as.numeric(upper))]
+      sim <- o$sim
+      
+      if (is.numeric(j)) { # If bin is numeric join on xmin/xmax from bin_info()
+        on_vec <- c("x>=xmin", "x<xmax")
+      } else { # If bin is character e.g., [lower,upper), join on lower/upper value
+        on_vec <- c("x>=lower", "x<upper")
+      }
+      
+      if (!is.null(o$strat.sim)) {
+        on_vec <- c(names(o$strat), on_vec)
+      }
+      # Perform join
+      sim[bin_intervals, on = on_vec, bin := i.bin]
+      cols_vec <- c(names(o$strat), "bin", "repl")
+      o <- update(o, .stratbinrepl = sim[, ..cols_vec])
+  }
+  
   # Assign an x value to each bin
   if (is.numeric(xbin)) {
     xbin <- data.table(xbin=xbin)[, .(xbin = unique(xbin)), by=stratbin]
@@ -1338,4 +1406,8 @@ check_order <- function(obs, sim, tol=1e-5) {
   packageStartupMessage(paste0("tidyvpc is part of Certara.R!\n",
                                "Follow the link below to learn more about PMx R package development at Certara.\n",
                                "https://certara.github.io/R-Certara/"))
+}
+
+.message <- function(msg) {
+  if (isTRUE(getOption("tidyvpc.verbose", default = FALSE))) message(msg)
 }

--- a/R/vpcstats.R
+++ b/R/vpcstats.R
@@ -272,6 +272,7 @@ censoring.tidyvpcobj <- function(o, blq, lloq, alq, uloq, data=o$data, ...) {
 #' @param o A \code{tidyvpcobj}.
 #' @param formula Formula for stratification.
 #' @param data Observed data supplied in \code{observed()} function.
+#' @param data.sim Simulated data supplied in \code{simulated()} function.
 #' @param ... Other arguments to include.
 #' @return Returns updated \code{tidyvpcobj} with stratification formula, stratification column(s), and strat.split datasets, which
 #'   is \code{obs} split by unique levels of stratification variable(s). Resulting datasets are of class object \code{data.frame}
@@ -308,9 +309,7 @@ stratify.tidyvpcobj <- function(o, formula, data=o$data, data.sim = NULL, ...) {
   }
   if (!is.null(data.sim)) {
     if (!o$replicate) {
-      .message("Obs/Sim are non replicates - cannot recycle strata from observed data in simulated data.")
-      .message("Expecting simulated data in `data` argument. Note, for observed
-            data, strata will be automatically extracted from o$data and cannot be overridden.")
+      .message("Obs/Sim are non replicates - cannot recycle strata from observed data and instead using `data.sim` argument for simulated data.")
       if (nrow(data.sim) == nrow(o$data)) {
         stop("Expecting simulated data in `data` argument")
       }
@@ -425,7 +424,7 @@ binning <- function(o, ...) UseMethod("binning")
 #' @rdname binning
 #' @export
 binning.tidyvpcobj <- function(o, bin, data=o$data, xbin="xmedian", centers, breaks, nbins, altx, stratum=NULL, by.strata=TRUE,  ...) {
-  keep <- i <- NULL
+  keep <- i <- lower <- upper <- i.bin <- NULL
   . <- list
 
   # If xbin is numeric, then that is the bin
@@ -588,7 +587,7 @@ binning.tidyvpcobj <- function(o, bin, data=o$data, xbin="xmedian", centers, bre
       # Perform join
       sim[bin_intervals, on = on_vec, bin := i.bin]
       cols_vec <- c(names(o$strat), "bin", "repl")
-      o <- update(o, .stratbinrepl = sim[, ..cols_vec])
+      o <- update(o, .stratbinrepl = sim[, .SD, .SDcols = cols_vec])
   }
   
   # Assign an x value to each bin

--- a/R/vpcstats_fun.R
+++ b/R/vpcstats_fun.R
@@ -37,7 +37,7 @@ vpcstats.tidyvpcobj <- function(o, vpc.type =c("continuous", "categorical"), qpr
 
   stopifnot(length(qpred) == 3)
 
-  repl <- ypc <- ypcvc <- y <- x <- blq <- lloq <- alq <- uloq <- NULL
+  repl <- ypc <- ypcvc <- y <- x <- blq <- lloq <- alq <- uloq <- bin <- NULL
   . <- list
   qconf <- c(0, 0.5, 1) + c(1, 0, -1)*(1 - conf.level)/2
 

--- a/R/vpcstats_fun.R
+++ b/R/vpcstats_fun.R
@@ -228,7 +228,13 @@ vpcstats.tidyvpcobj <- function(o, vpc.type =c("continuous", "categorical"), qpr
       .stratbinquant <- qsim[, !c("repl", "y")]
       qconf <- c(0, 0.5, 1) + c(1, 0, -1)*(1 - conf.level)/2
       qqsim <- qsim[, quant_noloq(y, probs=qconf, qname=c("lo", "md", "hi"), type = quantile.type), by=.stratbinquant]
-      stats <- qobs[qqsim, on=names(.stratbinquant)]
+      
+      if (o$replicate) {
+        stats <- qobs[qqsim, on=names(.stratbinquant)]
+      } else {
+        # perform full join if not replicate, may be bins beyonds limits of data
+        stats <- merge(qobs, qqsim, by = names(.stratbinquant), all = TRUE)
+      }
       stats <- xbin[stats, on=names(stratbin)]
       setkeyv(stats, c(names(o$strat), "xbin"))
 

--- a/man/binning.Rd
+++ b/man/binning.Rd
@@ -48,7 +48,7 @@ binning(o, ...)
 Updates \code{tidyvpcobj} with \code{data.frame} containing bin information including left/right boundaries and midpoint, as specified in \code{xbin} argument.
 }
 \description{
-This function executes binning methods available in classInt i.e. "jenks", "kmeans", "sd", "pretty", "pam", "kmeans", "hclust", "bclust", "fisher", "dpih", "box", "headtails", and "maximum".
+This function executes binning methods available in classInt e.g., "jenks", "kmeans", "sd", "pretty", "pam", "kmeans", "hclust", "bclust", "fisher", "dpih", "box", "headtails", and "maximum".
 You may also bin directly on x-variable or alternatively specify "centers" or "breaks". For explanation of binning methods see \code{\link[classInt]{classIntervals}}.
 }
 \examples{

--- a/man/simulated.Rd
+++ b/man/simulated.Rd
@@ -7,7 +7,7 @@
 \usage{
 simulated(o, ...)
 
-\method{simulated}{tidyvpcobj}(o, data, ysim, ..., xsim)
+\method{simulated}{tidyvpcobj}(o, data, ysim, xsim, repl, ...)
 }
 \arguments{
 \item{o}{A \code{tidyvpcobj}.}
@@ -18,7 +18,9 @@ simulated(o, ...)
 
 \item{ysim}{Numeric y-variable, typically named DV.}
 
-\item{xsim}{Numeric x-variable, typically named TIME.}
+\item{xsim}{Numeric x-variable, typically named TIME. This argument is not required, see details below.}
+
+\item{repl}{Numeric replicate variable, typically named REPL. This argument is not required, see details below.}
 }
 \value{
 A \code{tidyvpcobj} containing simulated dataset \code{sim} formatted with columns \code{x}, \code{y}, and \code{repl}, which indicates the replicate number.

--- a/man/stratify.Rd
+++ b/man/stratify.Rd
@@ -7,7 +7,7 @@
 \usage{
 stratify(o, ...)
 
-\method{stratify}{tidyvpcobj}(o, formula, data = o$data, ...)
+\method{stratify}{tidyvpcobj}(o, formula, data = o$data, data.sim = NULL, ...)
 }
 \arguments{
 \item{o}{A \code{tidyvpcobj}.}

--- a/man/stratify.Rd
+++ b/man/stratify.Rd
@@ -17,6 +17,8 @@ stratify(o, ...)
 \item{formula}{Formula for stratification.}
 
 \item{data}{Observed data supplied in \code{observed()} function.}
+
+\item{data.sim}{Simulated data supplied in \code{simulated()} function.}
 }
 \value{
 Returns updated \code{tidyvpcobj} with stratification formula, stratification column(s), and strat.split datasets, which

--- a/tests/testthat/test-non_replicate.R
+++ b/tests/testthat/test-non_replicate.R
@@ -1,0 +1,56 @@
+test_that("non-replicate data warnings and errors are given", {
+  obs <- tidyvpc::obs_data[MDV == 0]
+  sim <- tidyvpc::sim_data[MDV == 0]
+  sim$TIME <- sim$TIME + rnorm(1)
+  
+  vpc <- observed(obs, x = TIME, yobs = DV)
+  expect_warning(simulated(vpc, sim, xsim = TIME, ysim = DV),
+                 regexp = "Values of `xsim` do not match observed data x-values.")
+  
+  expect_warning(simulated(vpc, sim[NTIME != 1.50], ysim = DV),
+                 regexp = "The simulated data is not a replicate of the observed data. Ensure that you filtered your observed data to remove MDV rows. If this is intentional, use the `xsim` and `repl` arguments for non-replicate support.")
+})
+
+test_that("binning works with non-replicate data", {
+  obs <- tidyvpc::obs_data[MDV == 0]
+  sim <- tidyvpc::sim_data[MDV == 0]
+  sim$GENDER <- rep(obs$GENDER, nrow(sim) / nrow(obs))
+  sim$STUDY <- rep(obs$STUDY, nrow(sim) / nrow(obs))
+  sim_non_rep <- sim[TIME < 10]
+  nrep <- nrow(sim_non_rep) / nrow(obs)
+  
+  expect_false(nrep == as.integer(nrep))
+  
+  vpc <-
+    observed(obs, x = TIME, yobs = DV) %>%
+    simulated(sim_non_rep,
+              xsim = TIME,
+              ysim = DV,
+              repl = REP) %>%
+    binning(bin = "jenks", nbins = 4)
+  obs_bins <- vpc$.stratbin
+  sim_bins <- vpc$.stratbinrepl
+  expect_equal(unique(obs_bins), unique(sim_bins[!is.na(bin),!c("repl"), with = FALSE]))
+  
+  vpc <-
+    observed(obs, x = TIME, yobs = DV) %>%
+    simulated(sim_non_rep,
+              xsim = TIME,
+              ysim = DV,
+              repl = REP) %>%
+    stratify( ~ GENDER, data.sim = sim_non_rep) %>%
+    binning(bin = "jenks", nbins = 4)
+  obs_bins <- vpc$.stratbin
+  sim_bins <- vpc$.stratbinrepl
+  expect_equal(unique(obs_bins), unique(sim_bins[!is.na(bin),!c("repl"), with = FALSE]))
+  
+  vpc <-
+    observed(obs, x = TIME, yobs = DV) %>%
+    simulated(sim_non_rep,
+              xsim = TIME,
+              ysim = DV,
+              repl = REP) %>%
+    binning(bin = "centers", centers = c(1, 3, 5, 7, 9)) %>%
+    vpcstats()
+  expect_s3_class(vpc, "tidyvpcobj")
+})

--- a/tests/testthat/test-vpcstats.R
+++ b/tests/testthat/test-vpcstats.R
@@ -13,14 +13,14 @@ test_that("simulated.tidyvpcobj detects row count mismatches", {
     xsim = x,
     ysim = y
   ))
-  expect_error(
+  expect_warning(
     simulated(
       vpcobj_o,
       data = data.frame(x = 0:2, y = c(0, 3, 4)),
       x = x,
       ysim = y
     ),
-    regexp = "The number of simulated rows is not a multiple of the number of observed rows.  Ensure that you filtered your observed data to remove MDV rows.",
+    regexp = "The simulated data is not a replicate of the observed data. Ensure that you filtered your observed data to remove MDV rows. If this is intentional, use the `xsim` and `repl` arguments for non-replicate support.",
     fixed = TRUE
   )
 })
@@ -40,14 +40,14 @@ test_that("simulated.tidyvpcobj detects x-variable mismatches", {
     xsim = x,
     ysim = y
   ))
-  expect_error(
+  expect_warning(
     simulated(
       vpcobj_o,
       data = data.frame(x = c(0:2, 1), y = c(0, 3, 0, 4)),
       xsim = x,
       ysim = y
     ),
-    regexp = "Values of `xsim` do not match observed data x-values.  Ensure that you filtered your observed data to remove MDV rows.",
+    regexp = "Values of `xsim` do not match observed data x-values.",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
To support cases where simulated data is not a replicate of the observed data. [#64]
- Add optional `repl` argument in `simulated.tidyvpcobj` to identify replicate column in simulated data
- Add `data.sim` argument in `stratify.tidyvpcobj` to identify strata in simulated data
- Change existing non-replicate error checks to warnings
- Both `binning()` and `binless()` are supported

Example usage:

``` r
library(data.table)
library(tidyvpc)
library(magrittr)

# Can additionally toggle tidyvpc package specific verbosity
options("tidyvpc.verbose" = TRUE)

obs <- tidyvpc::obs_data[MDV==0]
sim <- tidyvpc::sim_data[MDV==0]
sim$GENDER <- rep(obs$GENDER, nrow(sim) / nrow(obs))

sim_rich <- sim[, {
  ntime_seq <- seq(from = min(TIME),
                   to   = max(TIME),
                   by   = 0.01)
  dv_interp <- approx(x = TIME, y = DV, xout = ntime_seq)$y
    data.table(TIME = ntime_seq,
             DV    = dv_interp,
             GENDER = GENDER[1])
}, by = .(ID, REP)]


vpc <- observed(obs, x = TIME, yobs = DV) %>%
  simulated(sim,
            ysim = DV) %>%
  binning(bin = "jenks", nbins = 5) %>%
  vpcstats()

plot(vpc)

vpc_non_rep <-
  observed(obs, x = TIME, yobs = DV) %>%
  simulated(sim_rich,
            xsim = TIME,
            ysim = DV,
            repl = REP) %>%
  binning(bin = "jenks", nbins = 5) %>%
  vpcstats()

plot(vpc_non_rep)

vpc_non_rep_strat <-
  observed(obs, x = TIME, yobs = DV) %>%
  simulated(sim_rich,
            xsim = TIME,
            ysim = DV,
            repl = REP) %>%
  stratify(~ GENDER, data.sim = sim_rich) %>% #specify data.sim arg 
  binning(bin = "jenks", nbins = 5) %>%
  vpcstats()

plot(vpc_non_rep_strat)
```


